### PR TITLE
modify function: CheckIpPermission

### DIFF
--- a/qpipe.c
+++ b/qpipe.c
@@ -1651,7 +1651,7 @@ int CheckIpPermission(struct sockaddr_in * pIp, PROG_ARGS * qpipe_args)
         netmask = GetMaskByLen(qpipe_args->masklen[i]);
         netmask = htonl(netmask);
 
-        if (((pIp->sin_addr.s_addr)&netmask) == ((qpipe_args->netip[i]) &netmask))
+        if ( ((pIp->sin_addr.s_addr)&netmask) == ((qpipe_args->netip[i]) &netmask) )
         {
             return 1;
         }

--- a/qpipe.c
+++ b/qpipe.c
@@ -1651,7 +1651,7 @@ int CheckIpPermission(struct sockaddr_in * pIp, PROG_ARGS * qpipe_args)
         netmask = GetMaskByLen(qpipe_args->masklen[i]);
         netmask = htonl(netmask);
 
-        if ( (pIp->sin_addr.s_addr & netmask) == qpipe_args->netip[i])
+        if (((pIp->sin_addr.s_addr)&netmask) == ((qpipe_args->netip[i]) &netmask))
         {
             return 1;
         }


### PR DESCRIPTION
use netmask for server, the original condition need modify. for example:
the server: ./qpipe -n 127.0.0.1/24 -p 5500
the client: ./qpipe -s 127.0.0.1 -p 5500 -c 'cat 1.txt' ,  it reports:
2015-11-15 15:44:17 : ERROR : Server return error: Client does not allow access to the server!
